### PR TITLE
move the category setup to module initialization

### DIFF
--- a/Ambit/Source/Ambit/AmbitModule.cpp
+++ b/Ambit/Source/Ambit/AmbitModule.cpp
@@ -13,6 +13,7 @@
 //   limitations under the License.
 
 #include "AmbitModule.h"
+
 #include "Mode/AmbitMode.h"
 #include "Mode/AmbitWidget.h"
 
@@ -23,6 +24,8 @@
 #include "Actors/Spawners/SpawnWithHoudini.h"
 #include "Actors/EditorDetails/SpawnerDetails.h"
 
+#include "EditorTutorial.h"
+#include "IIntroTutorials.h"
 #include "LevelEditor.h"
 
 #include "Styling/SlateStyleRegistry.h"
@@ -115,6 +118,18 @@ void FAmbitModule::Initialize()
     StyleSet->Set("Notification.Ambit", new FSlateImageBrush(IconsDir + "Ambit_Icon_1024.png", Icon32x32));
 
     FSlateStyleRegistry::RegisterSlateStyle(*StyleSet.Get());
+
+    // Register the Ambit tutorial category with the tutorial browser.
+    FTutorialCategory AWSAmbitCategory = FTutorialCategory();
+    AWSAmbitCategory.Identifier = "AWSAmbit";
+    AWSAmbitCategory.Title = NSLOCTEXT("TutorialCategories", "AWSAmbitTitle", "AWS Ambit");
+    AWSAmbitCategory.Description = NSLOCTEXT("TutorialCategories", "AWSAmbitDescription", "This tutorial will cover how AWS Ambit works.");
+    AWSAmbitCategory.Icon = "LevelEditor.Ambit";
+    AWSAmbitCategory.Texture = FSoftObjectPath("/Ambit/Icons/AmbitIcon");
+    AWSAmbitCategory.SortOrder = 100;
+
+    IIntroTutorials& IntroTutorials = FModuleManager::LoadModuleChecked<IIntroTutorials>(TEXT("IntroTutorials"));
+    IntroTutorials.RegisterCategory(AWSAmbitCategory);
 }
 
 END_SLATE_FUNCTION_BUILD_OPTIMIZATION

--- a/Ambit/Source/Ambit/Mode/AmbitWidget.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWidget.cpp
@@ -78,18 +78,7 @@ void SAmbitWidget::Construct(const FArguments& InArgs, TSharedRef<FAmbitModeTool
 
     FAmbitMode* AmbitMode = GetEditorMode();
 
-    // Register the Ambit tutorial category with the tutorial browser.
-    FTutorialCategory AWSAmbitCategory = FTutorialCategory();
-    AWSAmbitCategory.Identifier = "AWSAmbit";
-    AWSAmbitCategory.Title = NSLOCTEXT("TutorialCategories", "AWSAmbitTitle", "AWS Ambit");
-    AWSAmbitCategory.Description = NSLOCTEXT("TutorialCategories", "AWSAmbitDescription", "This tutorial will cover how AWS Ambit works.");
-    AWSAmbitCategory.Icon = "LevelEditor.Ambit";
-    AWSAmbitCategory.Texture = FSoftObjectPath("/Ambit/Icons/AmbitIcon");
-    AWSAmbitCategory.SortOrder = 100;
-
     IIntroTutorials& IntroTutorials = FModuleManager::LoadModuleChecked<IIntroTutorials>(TEXT("IntroTutorials"));
-    IntroTutorials.RegisterCategory(AWSAmbitCategory);
-
 
     FMargin StandardLeftPadding(6.f, 3.f, 3.f, 3.f);
     FMargin StandardRightPadding(3.f, 3.f, 6.f, 3.f);


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
The category failed to consistently initialize and include all tutorials. The reason was the initialization of category was later than the initialization of the Ambit module.

## What was the solution? (How)
We moved the category initialization process to the module startup and it solves the issue.

## What artifacts are related to this change?
Internal Issue ID: P55922913

## What is the impact of this change? (Focus on the customer experience)
Customers are able to find the AWS Ambit category in the tutorial window and after opening it, they can access four in-editor tutorials to get familiar with AWS Ambit mode.

## Are you adding any new dependencies to the system?
N/A

## How were these changes tested?
Manually testing and verified by the teammates offline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.