### PR TITLE
Fix 'Follow Spline Rotation' behavior

### DIFF
--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.h
@@ -42,8 +42,8 @@ public:
     bool bSnapToSurfaceBelow = false;
 
     /**
-    Rotation will follow the spline. Overrides degrees of rotation.
-    */
+     * Rotation of the spawned objects will be relative to the spline orientation.
+     */
     UPROPERTY(EditAnywhere, Category = "Ambit Spawner",
         meta = (DisplayAfter = "DensityMax"))
     bool bFollowSplineRotation = false; // Put follow spline checkbox below density fields

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.cpp
@@ -284,8 +284,9 @@ TArray<FTransform> AmbitWorldHelpers::GenerateRandomLocationsFromSpline(
             FRotator Rotation(0, Random.FRandRange(RotationMin, RotationMax), 0);
             if (bFollowSplineRotation)
             {
-                Rotation.Yaw = Spline->GetRotationAtDistanceAlongSpline(
+                const float SplinePointRotation = Spline->GetRotationAtDistanceAlongSpline(
                     Distance, ESplineCoordinateSpace::World).Yaw;
+                Rotation.Yaw += SplinePointRotation;
             }
             // Combine "local" Yaw rotation generated from user inputted restrictions
             // with the adjusted rotation axis

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
@@ -997,6 +997,39 @@ void AmbitWorldHelpersSpec::Define()
             TestComponentActor->SetActorLocation(FVector(0, 0, 0));
             TestEqual("The array is empty", Transforms.Num(), 0);
         });
+
+        It("Will generate objects relative to spline rotation if bFollowSplineRotation is true", [this]()
+        {
+            const bool bFollowSplineRotation = true;
+
+            const float RotationMin = 120.0;
+            const float RotationMax = 120.0f;
+            RealSpline->SetLocationAtSplinePoint(1, FVector(0, 1000, 0), ESplineCoordinateSpace::World);
+
+            const TArray<AActor*> ActorsToSearch;
+            const int32 RandomSeed = 0;
+            const float DensityMin = 1.0f;
+            const float DensityMax = 1.0f;
+
+            const TArray<FTransform>& Transforms = AmbitWorldHelpers::GenerateRandomLocationsFromSpline(
+                RealSpline, ActorsToSearch, RandomSeed, false, DensityMin,
+                DensityMax, RotationMin, RotationMax, bFollowSplineRotation);
+            UE_LOG(LogAmbit, Display, TEXT("The number of Transforms is: %d"), Transforms.Num());
+
+            const float SplinePointRotation = RealSpline->GetRotationAtSplinePoint(1, ESplineCoordinateSpace::World).Yaw;
+            const float ExpectedRotation = RotationMin + SplinePointRotation;
+            UE_LOG(LogAmbit, Display, TEXT("Expected Rotation: %f"), ExpectedRotation);
+
+            for (const FTransform& OneTransform : Transforms)
+            {
+                const float SplineRotation = OneTransform.Rotator().GetDenormalized().Yaw;
+                UE_LOG(LogAmbit, Display, TEXT("Yaw: %f"), SplineRotation);
+
+                TestTrue(
+                    "We expect the determined transform to be equal to the sum of the spline rotation and min rotation value",
+                    FMath::IsNearlyEqual(SplineRotation, ExpectedRotation, 0.01f));
+            }
+        });
     });
 
     Describe("GenerateRandomLocationsFromActor()", [this]()

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
@@ -1002,7 +1002,7 @@ void AmbitWorldHelpersSpec::Define()
         {
             const bool bFollowSplineRotation = true;
 
-            const float RotationMin = 120.0;
+            const float RotationMin = 120.0f;
             const float RotationMax = 120.0f;
             RealSpline->SetLocationAtSplinePoint(1, FVector(0, 1000, 0), ESplineCoordinateSpace::World);
 
@@ -1014,16 +1014,12 @@ void AmbitWorldHelpersSpec::Define()
             const TArray<FTransform>& Transforms = AmbitWorldHelpers::GenerateRandomLocationsFromSpline(
                 RealSpline, ActorsToSearch, RandomSeed, false, DensityMin,
                 DensityMax, RotationMin, RotationMax, bFollowSplineRotation);
-            UE_LOG(LogAmbit, Display, TEXT("The number of Transforms is: %d"), Transforms.Num());
 
-            const float SplinePointRotation = RealSpline->GetRotationAtSplinePoint(1, ESplineCoordinateSpace::World).Yaw;
-            const float ExpectedRotation = RotationMin + SplinePointRotation;
-            UE_LOG(LogAmbit, Display, TEXT("Expected Rotation: %f"), ExpectedRotation);
+            const float ExpectedRotation = 210.0f;
 
             for (const FTransform& OneTransform : Transforms)
             {
                 const float SplineRotation = OneTransform.Rotator().GetDenormalized().Yaw;
-                UE_LOG(LogAmbit, Display, TEXT("Yaw: %f"), SplineRotation);
 
                 TestTrue(
                     "We expect the determined transform to be equal to the sum of the spline rotation and min rotation value",


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
Objects weren't rotated relative to the spline orientation when `bFollowSplineRotation` was set to `true`

## What was the solution? (How)
- Spline rotation is taken into consideration when calculating final rotation at a spawn point. 
- Unit test added to ensure accurate behavior

## What artifacts are related to this change?
* Sim Ticket: P53273636

## What is the impact of this change? (Focus on the customer experience)
More accurate object rotation, possibly causing lesser confusion for the user when dealing with complex splines.

## Are you adding any new dependencies to the system?
No

## How were these changes tested?
- Locally using the Spawn on Path actor
- Unit test

## How does this commit make you feel? (Optional, but encouraged)
Good, since I'm learning more about Unreal Engine

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.