### PR TITLE
Include a PR template in repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## What was the problem/requirement? (What/Why)
+_A detailed description of the problem and the underlying cause_
+
+## What was the solution? (How)
+_A detailed description about the solution, and the changes you made_
+
+## What artifacts are related to this change?
+Issues: _issue id's go here_
+
+## What is the impact of this change?
+_Describe how users of this plugin will be affected by this change_
+
+## Are you adding any new dependencies to the system?
+_For example, new API calls or references to dependent resources. Have you verified the information does not already exist?_
+
+## How were these changes tested?
+_Describe the testing that you performed, in excruciating detail, to verify the correctness of this CR._
+
+## How does this commit make you feel? (Optional, but encouraged)
+:)
+
+
+----
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
Developers have to copy-paste the PR template when creating new PRs.

## What was the solution? (How)
Added a PR template to the repo for use when a new PR is created.

## What artifacts are related to this change?
Issues: SISU-177

## What is the impact of this change? (Focus on the customer experience)
Developers no longer have to rely on external PR templates and can create PRs faster.

## Are you adding any new dependencies to the system?
No.

## How does this commit make you feel? (Optional, but encouraged)
Yay, automation

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.