### PR TITLE
Remove HoudiniDigitalAssets folder from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Ambit is implemented as a plugin for Unreal Engine and has been tested for compa
 ```
 📂 Ambit/                      ~ Source code for the Ambit UE4 plug-in
 📂 docs/                       ~ Source for Ambit documentation
-📂 HoudiniDigitalAssets/       ~ Compiled HDAs for use with Ambit
 📄 CONTRIBUTING.md             ~ Guidelines for contributing to this project
 📄 LICENSE                     ~ This project's licensing terms
 📄 NOTICE.md                   ~ Relevant copyright notices


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
README mentioned the HoudiniDigitalAssets folder which has been previously removed.

## What was the solution? (How)
Removed the mention from the README

## What artifacts are related to this change?
Issues: N/A

## What is the impact of this change?
Up-to-date README

## Are you adding any new dependencies to the system?
No

## How were these changes tested?
N/A

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
