### PR TITLE
Mock calls to S3 in ConfigImportExport tests

### DIFF
--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -828,7 +828,7 @@ bool UConfigImportExport::CreateBucket(const FString& AwsRegion, const FString& 
     TSet<FString> BucketsSet;
     try
     {
-        BucketsSet = AWSWrapper::ListBuckets();
+        BucketsSet = LambdaS3ListBuckets();
     }
     catch (const std::runtime_error& Re)
     {
@@ -841,7 +841,7 @@ bool UConfigImportExport::CreateBucket(const FString& AwsRegion, const FString& 
     {
         try
         {
-            AWSWrapper::CreateBucketWithEncryption(AwsRegion, BucketName);
+            LambdaS3CreateBucket(AwsRegion, BucketName);
         }
         catch (const std::invalid_argument& Ia)
         {

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -297,3 +297,15 @@ private:
      */
     TMap<FString, TSharedPtr<FJsonObject>> AllSpawnerConfiguration;
 };
+
+/**
+* Calls AWSWrapper::ListBuckets
+* Allows for injection of the function so that it can be changed for functional testing purposes.
+*/
+static TFunction<TSet<FString>()> LambdaS3ListBuckets = AWSWrapper::ListBuckets;
+
+/**
+* Calls AWSWrapper::CreateBucketWithEncryption
+* Allows for injection of the function so that it can be changed for functional testing purposes.
+*/
+static TFunction<void(const FString& Region, const FString& BucketName)> LambdaS3CreateBucket = AWSWrapper::CreateBucketWithEncryption;

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -425,6 +425,22 @@ void ConfigImportExportSpec::Define()
             };
 
             Exporter->SetMockWriteFile(MockWrite);
+
+            auto MockListBuckets = []() -> TSet<FString>
+            {
+                TSet<FString> setBuckets;
+                setBuckets.Add("BucketName");
+                return setBuckets;
+            };
+
+            Exporter->SetMockS3ListBuckets(MockListBuckets);
+
+            auto MockCreateBucket = [](const FString& Region, const FString& BucketName) -> void
+            {
+                return;
+            };
+
+            Exporter->SetMockS3CreateBucket(MockCreateBucket);
         });
 
         Describe("When Writing to Disk", [this]()

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -488,8 +488,14 @@ void ConfigImportExportSpec::Define()
                     };
                     Exporter->SetMockPutObjectS3(MockWriteToS3);
 
+                    auto MockCreateBucket = [](const FString& Region, const FString& BucketName) -> void
+                    {
+                        throw std::invalid_argument("The bucket name or region is empty");
+                    };
+                    Exporter->SetMockS3CreateBucket(MockCreateBucket);
+
                     // Must be set before we call the function.
-                    AddExpectedError("The bucket name or region is empty", EAutomationExpectedErrorFlags::Contains, 2);
+                    AddExpectedError("The bucket name or region is empty", EAutomationExpectedErrorFlags::Contains, 1);
 
                     const TMap<FString, TSharedPtr<FJsonObject>> FakeArray;
                     const bool bWroteSuccess = Exporter->ProcessSdfForExport(FakeArray, true);

--- a/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
@@ -55,6 +55,24 @@ public:
     };
 
     /**
+    * Overrides the default behavior of S3ListBuckets, the function called to list all buckets in an account, to be overwritten with
+    * the function passed in.
+    */
+    void SetMockS3ListBuckets(TFunction<TSet<FString>()> MockFunction)
+    {
+        LambdaS3ListBuckets = std::move(MockFunction);
+    }
+
+    /**
+    * Overrides the default behavior of S3CreateBucket, the function called to create a new bucket for ____, to be overwritten with
+    * the function passed in.
+    */
+    void SetMockS3CreateBucket(TFunction<void(const FString& Region, const FString& BucketName)> MockFunction)
+    {
+        LambdaS3CreateBucket = std::move(MockFunction);
+    }
+
+    /**
      * Sets the DoneDelegate to be the value specified. Used in "Latent" Automation Tests.
      */
     void SetSdfProcessDone(FDoneDelegate const& DoneEvent)


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
Some of the ConfigImportExport tests were failing on our CI/CD pipeline because the build instance is not set up with AWS credentials with access to S3, and the tests attempt several calls to S3. Similarly, anyone who has not run `aws configure` locally would expect to see these tests fail.

## What was the solution? (How)
As connectivity to S3 is not the feature under test -- these are unit tests, not integration tests -- I defined function references to the AWS calls so we could replace them with simple lambdas in the unit tests that don't attempt network calls. 

## What artifacts are related to this change?
Issues: AMBIT-3

## What is the impact of this change?
Developers will no longer be required to run `aws configure` or otherwise setting up AWS credentials locally before being able to successfully run the ConfigImportExport tests.

## Are you adding any new dependencies to the system?
No.

## How were these changes tested?
1. Without having AWS credentials configured, I ran the ConfigImportExport unit tests from the command line and ensured that all unit tests passed: `.\RunUAT.bat BuildCookRun -project="ambit-demo\AmbitDemo.uproject" -unattended -clean -build -package -nullrhi -nosound -run -editortest "-RunAutomationTest=Ambit.ConfigImportExport"`

2. I then ensured all unit tests passed: `.\RunUAT.bat BuildCookRun -project="ambit-demo\AmbitDemo.uproject" -unattended -clean -build -package -nullrhi -nosound -run -editortest "-RunAutomationTest=Ambit"`

3. I made local modifications that removed the lambda mocks from the unit tests, so that the functions were referencing the original AWS functions to ensure calls to S3 still worked as expected. 

4. Using the Unreal editor, I used the batch permutation generator functionality with a bucket name that didn't exist to test S3 bucket creation. This worked as expected.

## How does this commit make you feel? (Optional, but encouraged)
Excited! This change gets us one step closer to a working CI/CD pipeline...


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
