### PR TITLE
Separate integration tests from unit tests

### DIFF
--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.spec.cpp
@@ -20,7 +20,7 @@
 #include <AmbitUtils/JsonHelpers.h>
 
 
-BEGIN_DEFINE_SPEC(SpawnedObjectConfigSpec, "Ambit.SpawnedObjectConfig",
+BEGIN_DEFINE_SPEC(SpawnedObjectConfigSpec, "Ambit.Unit.SpawnedObjectConfig",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     USpawnedObjectConfig* Config;

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.spec.cpp
@@ -19,7 +19,7 @@
 
 #include <AmbitUtils/JsonHelpers.h>
 
-BEGIN_DEFINE_SPEC(SpawnedVehiclePathConfigSpec, "Ambit.SpawnedVehiclePathConfig",
+BEGIN_DEFINE_SPEC(SpawnedVehiclePathConfigSpec, "Ambit.Unit.SpawnedVehiclePathConfig",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     USpawnedVehiclePathConfig* Config;

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolume.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolume.spec.cpp
@@ -18,7 +18,7 @@
 
 #include <AmbitUtils/JsonHelpers.h>
 
-BEGIN_DEFINE_SPEC(SpawnInVolumeConfigSpec, "Ambit.SpawnInVolumeConfig",
+BEGIN_DEFINE_SPEC(SpawnInVolumeConfigSpec, "Ambit.Unit.SpawnInVolumeConfig",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     FSpawnInVolumeConfig Config;

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.spec.cpp
@@ -19,7 +19,7 @@
 
 #include <AmbitUtils/JsonHelpers.h>
 
-BEGIN_DEFINE_SPEC(SpawnOnPathSpec, "Ambit.SpawnOnPath",
+BEGIN_DEFINE_SPEC(SpawnOnPathSpec, "Ambit.Unit.SpawnOnPath",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     FSpawnOnPathConfig Config;

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.spec.cpp
@@ -22,7 +22,7 @@
 
 #include <AmbitUtils/JsonHelpers.h>
 
-BEGIN_DEFINE_SPEC(SpawnerBaseConfigSpec, "Ambit.AmbitSpawnerBaseConfig",
+BEGIN_DEFINE_SPEC(SpawnerBaseConfigSpec, "Ambit.Unit.AmbitSpawnerBaseConfig",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     FSpawnerBaseConfig Config;

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.spec.cpp
@@ -21,7 +21,7 @@
 
 #include "Ambit/Actors/SpawnerConfigs/SpawnInVolumeConfig.h"
 
-BEGIN_DEFINE_SPEC(SpawnInVolumeSpec, "Ambit.SpawnInVolume",
+BEGIN_DEFINE_SPEC(SpawnInVolumeSpec, "Ambit.Unit.SpawnInVolume",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     ASpawnInVolume* Spawner;

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.spec.cpp
@@ -22,7 +22,7 @@
 
 #include "Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.h"
 
-BEGIN_DEFINE_SPEC(SpawnOnPathConfig, "Ambit.SpawnOnPathConfig",
+BEGIN_DEFINE_SPEC(SpawnOnPathConfig, "Ambit.Unit.SpawnOnPathConfig",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     ASpawnOnPath* Spawner;

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.spec.cpp
@@ -20,7 +20,7 @@
 
 #include "Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.h"
 
-BEGIN_DEFINE_SPEC(SpawnOnSurfaceSpec, "Ambit.SpawnOnSurface",
+BEGIN_DEFINE_SPEC(SpawnOnSurfaceSpec, "Ambit.Unit.SpawnOnSurface",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     ASpawnOnSurface* Spawner;

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.spec.cpp
@@ -23,7 +23,7 @@
 #include "Ambit/Utils/AmbitWorldHelpers.h"
 
 
-BEGIN_DEFINE_SPEC(SpawnWithHoudiniSpec, "Ambit.SpawnWithHoudini",
+BEGIN_DEFINE_SPEC(SpawnWithHoudiniSpec, "Ambit.Integration.SpawnWithHoudini",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     UWorld* World;

--- a/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.spec.cpp
@@ -16,7 +16,7 @@
 
 #include "Misc/AutomationTest.h"
 
-DEFINE_SPEC(AmbitWeatherParametersSpec, "Ambit.AmbitWeatherParameters",
+DEFINE_SPEC(AmbitWeatherParametersSpec, "Ambit.Unit.AmbitWeatherParameters",
             EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
 void AmbitWeatherParametersSpec::Define()

--- a/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.spec.cpp
@@ -20,7 +20,7 @@
 
 #include <AmbitUtils/JsonHelpers.h>
 
-BEGIN_DEFINE_SPEC(BulkScenarioConfigurationSpec, "Ambit.BulkScenarioConfiguration",
+BEGIN_DEFINE_SPEC(BulkScenarioConfigurationSpec, "Ambit.Unit.BulkScenarioConfiguration",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     FBulkScenarioConfiguration BulkConfig;

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -32,7 +32,7 @@
 #include "Ambit/Mode/TestClasses/MockableConfigImportExport.h"
 #include "AmbitUtils/JsonHelpers.h"
 
-BEGIN_DEFINE_SPEC(ConfigImportExportSpec, "Ambit.ConfigImportExport",
+BEGIN_DEFINE_SPEC(ConfigImportExportSpec, "Ambit.Unit.ConfigImportExport",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     TSharedPtr<FJsonObject> Json;

--- a/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.spec.cpp
@@ -25,7 +25,7 @@
 
 #include "AmbitWorldHelpers.h"
 
-BEGIN_DEFINE_SPEC(AmbitSpawnerCollisionHelpersSpec, "Ambit.AmbitSpawnerCollisionHelpers",
+BEGIN_DEFINE_SPEC(AmbitSpawnerCollisionHelpersSpec, "Ambit.Unit.AmbitSpawnerCollisionHelpers",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     UWorld* World;

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
@@ -24,7 +24,7 @@
 #include "Tests/AutomationEditorCommon.h"
 #include "UObject/UObjectGlobals.h"
 
-BEGIN_DEFINE_SPEC(AmbitWorldHelpersSpec, "Ambit.AmbitWorldHelpers",
+BEGIN_DEFINE_SPEC(AmbitWorldHelpersSpec, "Ambit.Unit.AmbitWorldHelpers",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     UWorld* World;

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.spec.cpp
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.spec.cpp
@@ -16,7 +16,7 @@
 
 #include "Misc/AutomationTest.h"
 
-BEGIN_DEFINE_SPEC(AmbitVehiclePIDControllerSpec, "Ambit.AmbitVehiclePIDController",
+BEGIN_DEFINE_SPEC(AmbitVehiclePIDControllerSpec, "Ambit.Unit.AmbitVehiclePIDController",
                   EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
     FAmbitVehiclePIDController Controller;

--- a/Ambit/Source/AmbitUtils/MathHelpers.spec.cpp
+++ b/Ambit/Source/AmbitUtils/MathHelpers.spec.cpp
@@ -16,7 +16,7 @@
 
 #include "Misc/AutomationTest.h"
 
-DEFINE_SPEC(MathHelpersSpec, "AmbitUtils.MathHelpers",
+DEFINE_SPEC(MathHelpersSpec, "Ambit.Unit.Utils.MathHelpers",
             EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
 
 void MathHelpersSpec::Define()


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
Currently, the build pipeline isn't set up to be properly licensed to successfully run the Houdini tests. In the meantime, we'd like some way of running the unit test suite from the command line without these.

## What was the solution? (How)
The naming structure of the tests have changed to more explicitly move all tests under "Ambit.Unit" while the Houdini tests live under "Ambit.Integration". The "AmbitUtils" tests have moved to "Ambit.Unit.Utils".

When running the tests from the command line, Unreal only does forward string matching - passing in "Ambit" would run all of the tests (both organized under Unit and Integration), while "Ambit.Unit" would run all of the unit tests without running Ambit.Integration. 

I didn't want to explicitly list all the tests that should be run, as developers adding new unit tests would have to remember to add them to the pipeline. There is no concept of a negative filter - I can't tell it 'run all tests that match this string, but not these specific tests." 

Similarly, the only filter that _can_ be used from the command line is represented by the flags that fall under the [FilterMask](https://docs.unrealengine.com/4.27/en-US/API/Runtime/Core/Misc/EAutomationTestFlags__Type/) -- Smoke, Engine, Product, Perf, Stress, and Negative. All Ambit tests are marked as Product tests by default, which is IMO the right place for them - there's no separate category that really suits the integration tests.

## What artifacts are related to this change?
Issues: Ambit-10

## What is the impact of this change?
Developers running tests will notice that they are organized under a new structure, and will have to expand one more node to view class-specific tests. Otherwise it is just as simple to run all of the Ambit tests.

## Are you adding any new dependencies to the system?
None

## How were these changes tested?
* Visually checked organization of tests in the Editor 
* Ran just the unit tests from the command line, looked at output to ensure Houdini tests did not run: `.\RunUAT.bat BuildCookRun -project="D:\UnrealProjects\ambitdemo\ambit-demo\AmbitDemo.uproject" -unattended -clean -build -package -nullrhi -nosound -run -editortest "-RunAutomationTest=Ambit.Unit"`

## How does this commit make you feel? (Optional, but encouraged)
Fairly ambivalent


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
