### PR TITLE
User Guide: Fix broken links on "Automated Scenario Generation" page

### DIFF
--- a/docs/user-guide/docs-source/automated-scenario-generation.md
+++ b/docs/user-guide/docs-source/automated-scenario-generation.md
@@ -1,6 +1,6 @@
 # Automated Scenario Generation
 
-Ambit provides bulk scenario generation functionality. It does this by creating a batch of [individual SDFs](./manual-scenario-generation) based on making permutations from each setting specified. Alongside those it also has a standalone file called a [Bulk Scenario Configuration (BSC)](#utilizing-bulk-scenario-generation-file) file that indicates how the batch was created. 
+Ambit provides bulk scenario generation functionality. It does this by creating a batch of [individual SDFs](../manual-scenario-generation) based on making permutations from each setting specified. Alongside those it also has a standalone file called a [Bulk Scenario Configuration (BSC)](#utilizing-bulk-scenario-generation-file) file that indicates how the batch was created. 
 
 Before getting started, make sure to have properly set up your [AWS Account](/aws-setup#setup).
 

--- a/docs/user-guide/docs-source/automated-scenario-generation.md
+++ b/docs/user-guide/docs-source/automated-scenario-generation.md
@@ -1,6 +1,6 @@
 # Automated Scenario Generation
 
-Ambit provides bulk scenario generation functionality. It does this by creating a batch of [individual SDFs](./individual-scenario-generation/) based on making permutations from each setting specified. Alongside those it also has a standalone file called a [Bulk Scenario Configuration (BSC)](#utilizing-bulk-scenario-generation-file) file that indicates how the batch was created. 
+Ambit provides bulk scenario generation functionality. It does this by creating a batch of [individual SDFs](./manual-scenario-generation) based on making permutations from each setting specified. Alongside those it also has a standalone file called a [Bulk Scenario Configuration (BSC)](#utilizing-bulk-scenario-generation-file) file that indicates how the batch was created. 
 
 Before getting started, make sure to have properly set up your [AWS Account](/aws-setup#setup).
 
@@ -87,4 +87,5 @@ AllSpawnerConfigs: A list of spawner configurations by type.
   AmbitSpawner*: An individual type of spawner that has specified values for it. Each spawner has its own settings.
 ```
 
-To find the specification for the SDF, please refer to [this](./individual-scenario-generation.md#utilizing-scenario-definition-file) section.
+To find the specification for the SDF, please refer to [this](../manual-scenario-generation/#scenario-definition-file-specification) section.
+


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
There were two broken links on the "Automated Scenario Generation" page.

## What was the solution? (How)
Problem was caused by a recent renaming of pages. Updated links to reflect the new names.

## What artifacts are related to this change?
n/a

## What is the impact of this change?
Links will now work as users expect.

## Are you adding any new dependencies to the system?
No

## How were these changes tested?
- QA'd the docs locally using the `mkdocs serve` command.
- Kept a careful eye on the mkdocs terminal output to watch for broken link warnings that were missed previously.

## How does this commit make you feel? (Optional, but encouraged)
Any improvement to documentation always makes me :)


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
