### PR TITLE
Fix build issues with glTF unit tests

### DIFF
--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -15,7 +15,6 @@
 #include "ConfigImportExport.h"
 
 #include "BulkScenarioConfiguration.h"
-#include "GltfExport.h"
 #include "ScenarioDefinition.h"
 #include "WeatherTypes.h"
 #include "Containers/Queue.h"
@@ -56,6 +55,13 @@
   * A queue to keep track of all of the Configs that need exported to SDF.
  */
 TQueue<TSharedPtr<FScenarioDefinition>> QueuedSdfConfigToExport;
+
+//Constructor
+UConfigImportExport::UConfigImportExport()
+{
+    GltfExporter = NewObject<UGltfExport>();
+};
+
 
 FReply UConfigImportExport::OnImportSdf()
 {
@@ -467,7 +473,7 @@ FReply UConfigImportExport::OnExportMap()
                                                                            TargetPlatform);
 
             LambdaS3FileUpload(AwsRegion, BucketName, CompressedFile,
-                                   FPaths::Combine(*FPaths::ProjectIntermediateDir(), *CompressedFile));
+                               FPaths::Combine(*FPaths::ProjectIntermediateDir(), *CompressedFile));
         }
         catch (const std::invalid_argument& Ia)
         {
@@ -553,8 +559,7 @@ FReply UConfigImportExport::OnExportGltf()
     const FString FilePath = FPaths::Combine(OutputDir, Filename);
 
     // Perform the export to glTF.
-    UGltfExport* GltfExporter = NewObject<UGltfExport>();
-    const UGltfExport::GltfExportReturnCode ReturnCode = GltfExporter->Export(CurrentWorldContext, FilePath);
+    const UGltfExport::GltfExportReturnCode ReturnCode = ExportGltf(CurrentWorldContext, FilePath);
     if (ReturnCode == UGltfExport::ExporterNotFound)
     {
         ErrorMessage = "glTF Export: glTF Exporter plugin is not installed. \
@@ -584,13 +589,18 @@ FReply UConfigImportExport::OnExportGltf()
                                                                        FolderName, TargetPlatform);
 
         LambdaS3FileUpload(AwsRegion, BucketName, CompressedFile,
-                               FPaths::Combine(*FPaths::ProjectIntermediateDir(), *CompressedFile));
+                           FPaths::Combine(*FPaths::ProjectIntermediateDir(), *CompressedFile));
     }
 
     const FText NotificationText = NSLOCTEXT("Ambit", "MapUploadComplete", "Successfully uploaded to S3.");
     FAmbitModule::CreateAmbitNotification(NotificationText);
 
     return FReply::Handled();
+}
+
+UGltfExport* UConfigImportExport::GetGltfExporter() const
+{
+    return GltfExporter;
 }
 
 void UConfigImportExport::PrepareAllSpawnersObjectConfigs(bool bToS3)

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -559,8 +559,15 @@ FReply UConfigImportExport::OnExportGltf()
     const FString FilePath = FPaths::Combine(OutputDir, Filename);
 
     // Perform the export to glTF.
-    const UGltfExport::GltfExportReturnCode ReturnCode = ExportGltf(CurrentWorldContext, FilePath);
-    if (ReturnCode == UGltfExport::ExporterNotFound)
+    const UGltfExport::GltfExportReturnCode ReturnCode = LambdaExportGltf(CurrentWorldContext, FilePath);
+    if (ReturnCode == UGltfExport::ExporterNotInitialized)
+    {
+        ErrorMessage = "glTF Exporter not initialized.";
+        FMenuHelpers::LogErrorAndPopup(ErrorMessage);
+
+        return FReply::Handled();
+    }
+    if(ReturnCode == UGltfExport::ExporterNotFound)
     {
         ErrorMessage = "glTF Export: glTF Exporter plugin is not installed. \
         Follow the instructions in the User Guide to install the glTF Exporter plugin from the marketplace.";
@@ -919,3 +926,14 @@ void UAmbitExporterDelegateWatcher::SpawnedObjectConfigCompleted_Handler(
         AllSpawnerConfiguration.Empty();
     }
 }
+
+UGltfExport::GltfExportReturnCode UConfigImportExport::ExportGltf(UWorld* World, const FString& FilePath)
+{
+    if(!GltfExporter)
+    {
+        return UGltfExport::ExporterNotInitialized;
+    }
+
+    return GltfExporter->Export(World, FilePath);
+}
+

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "GltfExport.h"
 #include "ScenarioDefinition.h"
 #include "Dom/JsonObject.h"
 #include "Misc/AutomationTest.h"
@@ -39,6 +40,9 @@ class UConfigImportExport : public UObject
 {
     GENERATED_BODY()
 public:
+    //Constructor
+    UConfigImportExport();
+
     // SDF import and export
     /**
      * Starts the process to import an SDF file specified on screen.
@@ -107,6 +111,11 @@ public:
      */
     FReply OnExportGltf();
 
+    /**
+     * Gets a pointer to the UGltfExport object.
+     */
+    UGltfExport* GetGltfExporter() const;
+
 protected:
     /**
      * Calls AWSWrapper::PutObject
@@ -136,6 +145,16 @@ protected:
      */
     TFunction<FString(const FString& FileExtension, const FString& DefaultPath, const FString& Filename)>
     LambdaGetPathFromPopup = AmbitFileHelpers::GetPathForFileFromPopup;
+
+    /**
+     * Calls UGltfExport::Export()
+     * Allows for injection of the function to be changed. Should only be changed in testing.
+     */
+    TFunction<UGltfExport::GltfExportReturnCode(UWorld* WorldContext, const FString& FilePath)> ExportGltf = [this](
+        UWorld* WorldContext, const FString& FilePath)
+    {
+        return this->GetGltfExporter()->Export(WorldContext, FilePath);
+    };
 
     /**
     * For internal testing only. Returns when ProcessSdfForExport() has been completed and there are no more items in queue. 
@@ -254,6 +273,9 @@ private:
     {
         return "GeneratedScenarios-";
     }
+
+private:
+    UGltfExport* GltfExporter;
 };
 
 /**
@@ -316,4 +338,5 @@ static TFunction<TSet<FString>()> LambdaS3ListBuckets = AWSWrapper::ListBuckets;
 * Calls AWSWrapper::CreateBucketWithEncryption
 * Allows for injection of the function so that it can be changed for functional testing purposes.
 */
-static TFunction<void(const FString& Region, const FString& BucketName)> LambdaS3CreateBucket = AWSWrapper::CreateBucketWithEncryption;
+static TFunction<void(const FString& Region, const FString& BucketName)> LambdaS3CreateBucket =
+        AWSWrapper::CreateBucketWithEncryption;

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -150,10 +150,10 @@ protected:
      * Calls UGltfExport::Export()
      * Allows for injection of the function to be changed. Should only be changed in testing.
      */
-    TFunction<UGltfExport::GltfExportReturnCode(UWorld* WorldContext, const FString& FilePath)> ExportGltf = [this](
+    TFunction<UGltfExport::GltfExportReturnCode(UWorld* WorldContext, const FString& FilePath)> LambdaExportGltf = [this](
         UWorld* WorldContext, const FString& FilePath)
     {
-        return this->GetGltfExporter()->Export(WorldContext, FilePath);
+        return this->ExportGltf(WorldContext, FilePath);
     };
 
     /**
@@ -273,6 +273,16 @@ private:
     {
         return "GeneratedScenarios-";
     }
+
+    /**
+     * Run the glTF Export process.
+     *
+     * @param World The current World context.
+     * @param FilePath The output file path.
+     *
+     * @return GltfExportReturnCode enum
+     */
+    UGltfExport::GltfExportReturnCode ExportGltf(UWorld* World, const FString& FilePath);
 
 private:
     UGltfExport* GltfExporter;

--- a/Ambit/Source/Ambit/Mode/GltfExport.h
+++ b/Ambit/Source/Ambit/Mode/GltfExport.h
@@ -33,6 +33,7 @@ public:
      */
     enum GltfExportReturnCode
     {
+        ExporterNotInitialized,
         ExporterNotFound,
         WriteToFileError,
         Failed,

--- a/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
@@ -88,7 +88,7 @@ public:
      */
     void SetMockGltfExport(TFunction<UGltfExport::GltfExportReturnCode(UWorld* WorldContext, const FString& FilePath)> MockFunction)
     {
-        ExportGltf = std::move(MockFunction);
+        LambdaExportGltf = std::move(MockFunction);
     }
 
     /**

--- a/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/MockableConfigImportExport.h
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "Ambit/Mode/ConfigImportExport.h"
+#include "Ambit/Mode/TestClasses/MockableGltfExport.h"
 
 #include "MockableConfigImportExport.generated.h"
 
@@ -80,6 +81,14 @@ public:
     void SetMockS3CreateBucket(TFunction<void(const FString& Region, const FString& BucketName)> MockFunction)
     {
         LambdaS3CreateBucket = std::move(MockFunction);
+    }
+
+    /**
+     * Overrides the default behavior of ExportGltf, the function called to export as gltf.
+     */
+    void SetMockGltfExport(TFunction<UGltfExport::GltfExportReturnCode(UWorld* WorldContext, const FString& FilePath)> MockFunction)
+    {
+        ExportGltf = std::move(MockFunction);
     }
 
     /**


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
glTF unit tests were failing on the build system when run from the command line, but succeeded when run from the UE editor.

## What was the solution? (How)
The glTF Export function has been modified to include a mockable version when the unit tests are triggered.

## What artifacts are related to this change?
Issues: P58427867

## What is the impact of this change?
Build system will be not fail on the glTF unit tests anymore. No visible impact to devs.

## Are you adding any new dependencies to the system?
No

## How were these changes tested?
Locally by running the below command from Powershell. Run this command from your Engine > Build > BatchFiles folder.
```
.\RunUAT.bat BuildCookRun -project="D:\AmbitGithub\AmbitGithub.uproject" -unattended -clean -build -package -nullrhi -nosound -run -editortest "-RunAutomationTest=Ambit.Unit.ConfigImportExport"
```

## How does this commit make you feel? (Optional, but encouraged)
:)


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
