### PR TITLE
Fix ConfigImportExport unit test by adding mock to compress file

### DIFF
--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -941,7 +941,8 @@ void UConfigImportExport::SetMockWriteFile(
 };
 
 void UConfigImportExport::SetMockCompressFile(
-    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> MockFunction)
+    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName,
+                      const FString& TargetPlatform)> MockFunction)
 {
     LambdaCompressFile = std::move(MockFunction);
 };

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -591,7 +591,7 @@ FReply UConfigImportExport::OnExportGltf()
 
     for (const FString& TargetPlatform : TargetPlatforms)
     {
-        const FString& CompressedFile = AmbitFileHelpers::CompressFile(OutputDir, FPaths::ProjectIntermediateDir(),
+        const FString& CompressedFile = LambdaCompressFile(OutputDir, FPaths::ProjectIntermediateDir(),
                                                                        FolderName, TargetPlatform);
 
         LambdaS3FileUpload(AwsRegion, BucketName, CompressedFile,
@@ -938,6 +938,12 @@ void UConfigImportExport::SetMockWriteFile(
     TFunction<void(const FString& FilePath, const FString& OutString)> MockFunction)
 {
     LambdaWriteFileToDisk = std::move(MockFunction);
+};
+
+void UConfigImportExport::SetMockCompressFile(
+    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> MockFunction)
+{
+    LambdaCompressFile = std::move(MockFunction);
 };
 
 void UConfigImportExport::SetMockPutObjectS3(TFunction<bool(const FString& Region, const FString& BucketName,

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -101,6 +101,12 @@ public:
     void SetMockWriteFile(TFunction<void(const FString& FilePath, const FString& OutString)> MockFunction);
 
     /**
+     * Overrides the default behavior of LambdaCompressFile, the function called when a compress file is actually happening in ConfigImportExport,
+     * to be the function passed in.
+     */
+    void SetMockCompressFile(TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> MockFunction);
+
+    /**
      * Overrides the default behavior of LambdaPutS3Object, the function called when uploading an object to Amazon S3 in ConfigImportExport,
      * to be the function passed in.
      */
@@ -141,6 +147,13 @@ protected:
      */
     TFunction<void(const FString& FilePath, const FString& OutString)> LambdaWriteFileToDisk =
             AmbitFileHelpers::WriteFile;
+
+    /**
+     * Calls AmbitFileHelpers::CompressFile
+     * Allows for injection of the function to be changed. Should only be changed in testing.
+     */
+    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> LambdaCompressFile =
+        AmbitFileHelpers::CompressFile;
 
     /**
      * Calls AmbitFileHelpers::GetPathForFileFromPopup

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -104,7 +104,8 @@ public:
      * Overrides the default behavior of LambdaCompressFile, the function called when a compress file is actually happening in ConfigImportExport,
      * to be the function passed in.
      */
-    void SetMockCompressFile(TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> MockFunction);
+    void SetMockCompressFile(TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory,
+                                               const FString& FileName, const FString& TargetPlatform)> MockFunction);
 
     /**
      * Overrides the default behavior of LambdaPutS3Object, the function called when uploading an object to Amazon S3 in ConfigImportExport,
@@ -152,8 +153,9 @@ protected:
      * Calls AmbitFileHelpers::CompressFile
      * Allows for injection of the function to be changed. Should only be changed in testing.
      */
-    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform)> LambdaCompressFile =
-        AmbitFileHelpers::CompressFile;
+    TFunction<FString(const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName,
+                      const FString& TargetPlatform)> LambdaCompressFile =
+            AmbitFileHelpers::CompressFile;
 
     /**
      * Calls AmbitFileHelpers::GetPathForFileFromPopup

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -1107,7 +1107,8 @@ void ConfigImportExportSpec::Define()
                 return true;
             };
             Exporter->SetMockWriteFile(MockWrite);
-            auto MockCompress = [](const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform) -> FString
+            auto MockCompress = [](const FString& SourceDirectory, const FString& TargetDirectory,
+                                   const FString& FileName, const FString& TargetPlatform) -> FString
             {
                 return "FileName";
             };

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -1102,6 +1102,16 @@ void ConfigImportExportSpec::Define()
                 return true;
             };
             Exporter->SetMockS3FileUpload(MockS3FileUpload);
+            auto MockWrite = [](const FString& FilePath, const FString& OutString) -> bool
+            {
+                return true;
+            };
+            Exporter->SetMockWriteFile(MockWrite);
+            auto MockCompress = [](const FString& SourceDirectory, const FString& TargetDirectory, const FString& FileName, const FString& TargetPlatform) -> FString
+            {
+                return "FileName";
+            };
+            Exporter->SetMockCompressFile(MockCompress);
         });
 
         It("Should fail if no mesh to export", [this]()


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
OnExportGLTF unit test was failing due to calling compressFile in a testing environment

## What was the solution? (How)
Add lambda function which allows us to replace it with a mock function for compress file

## Are you adding any new dependencies to the system?
N/A

## How were these changes tested?
Unit tests pass now

## How does this commit make you feel? (Optional, but encouraged)
:)


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
