### PR TITLE
Update Information to Allow Publishing into UE Marketplace

### DIFF
--- a/Ambit/Ambit.uplugin
+++ b/Ambit/Ambit.uplugin
@@ -1,14 +1,14 @@
 {
   "FileVersion": 3,
   "Version": 1,
-  "VersionName": "v1.0.0",
+  "VersionName": "v1.0.1",
   "FriendlyName": "AWS Ambit Scenario Designer for Unreal Engine 4",
   "Description": "AWS Ambit Scenario Designer for Unreal Engine 4 (Ambit) is a suite of tools to streamline content creation at scale for autonomous vehicle and robotics simulation applications.",
   "Category": "Other",
   "CreatedBy": "Amazon Web Services, Inc",
   "CreatedByURL": "https://aws.amazon.com/",
   "DocsURL": "https://aws-samples.github.io/aws-ambit-scenario-designer-ue4/",
-  "MarketplaceURL": "",
+  "MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/cb1034a325c94e52b3ed08f6eb9ae4a0",
   "SupportURL": "https://github.com/aws-samples/aws-ambit-scenario-designer-ue4/issues",
   "EngineVersion": "4.27.0",
   "CanContainContent": true,
@@ -19,12 +19,18 @@
     {
       "Name": "Ambit",
       "Type": "Editor",
-      "LoadingPhase": "PostEngineInit"
+      "LoadingPhase": "PostEngineInit",
+      "WhitelistPlatforms": [
+        "Win64"
+      ]
     },
     {
       "Name": "AmbitUtils",
       "Type": "Editor",
-      "LoadingPhase": "Default"
+      "LoadingPhase": "Default",
+      "WhitelistPlatforms": [
+        "Win64"
+      ]
     },
     {
       "Name": "AWSUE4Module",

--- a/Ambit/Config/FilterPlugin.ini
+++ b/Ambit/Config/FilterPlugin.ini
@@ -8,3 +8,6 @@
 ;    /Binaries/ThirdParty/*.dll
 AWSAmbit.hda
 /Config/*
+LICENSE
+NOTICE.md
+THIRD_PARTY_LICENSES.md

--- a/Ambit/Config/FilterPlugin.ini
+++ b/Ambit/Config/FilterPlugin.ini
@@ -7,3 +7,4 @@
 ;    /Extras/...
 ;    /Binaries/ThirdParty/*.dll
 AWSAmbit.hda
+/Config/*

--- a/Ambit/LICENSE
+++ b/Ambit/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/Ambit/NOTICE.md
+++ b/Ambit/NOTICE.md
@@ -1,0 +1,4 @@
+### AWS Ambit Scenario Designer for Unreal Engine 4
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+

--- a/Ambit/Source/AWSUE4Module/AWSUE4Module.Build.cs
+++ b/Ambit/Source/AWSUE4Module/AWSUE4Module.Build.cs
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //   
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/AWSHelpers.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/AWSHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/AWSUE4Module.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/AWSUE4Module.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/AWSUEStringUtils.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/AWSUEStringUtils.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/AWSUEStringUtils.h
+++ b/Ambit/Source/AWSUE4Module/Private/AWSUEStringUtils.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/FirehoseUE4Client.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/FirehoseUE4Client.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/S3UEClient.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/S3UEClient.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Private/S3UEClient.spec.cpp
+++ b/Ambit/Source/AWSUE4Module/Private/S3UEClient.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Public/AWSHelpers.h
+++ b/Ambit/Source/AWSUE4Module/Public/AWSHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Public/AWSUE4Module.h
+++ b/Ambit/Source/AWSUE4Module/Public/AWSUE4Module.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Public/FirehoseUE4Client.h
+++ b/Ambit/Source/AWSUE4Module/Public/FirehoseUE4Client.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AWSUE4Module/Public/S3UEClient.h
+++ b/Ambit/Source/AWSUE4Module/Public/S3UEClient.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/EditorDetails/SpawnerDetails.cpp
+++ b/Ambit/Source/Ambit/Actors/EditorDetails/SpawnerDetails.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/EditorDetails/SpawnerDetails.h
+++ b/Ambit/Source/Ambit/Actors/EditorDetails/SpawnerDetails.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedObjectConfig.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnedObjectConfigs/SpawnedVehiclePathConfig.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolume.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolume.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolumeConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolumeConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolumeConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnInVolumeConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnOnPathConfig.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnVehiclePathConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnVehiclePathConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnVehiclePathConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnVehiclePathConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnWithHoudiniConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnWithHoudiniConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnWithHoudiniConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnWithHoudiniConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.h
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/SpawnerConfigs/SpawnerBaseConfig.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/AmbitSpawner.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/AmbitSpawner.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnInVolume.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnPath.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnOnSurface.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnVehiclePath.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnVehiclePath.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnVehiclePath.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnVehiclePath.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.cpp
@@ -1,4 +1,4 @@
-﻿//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+﻿//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.h
@@ -1,4 +1,4 @@
-﻿//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+﻿//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.spec.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnWithHoudini.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnerBase.cpp
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnerBase.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/SpawnerBase.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/SpawnerBase.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Actors/Spawners/TestClasses/MockableSpawner.h
+++ b/Ambit/Source/Ambit/Actors/Spawners/TestClasses/MockableSpawner.h
@@ -1,4 +1,4 @@
-﻿//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+﻿//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Ambit.Build.cs
+++ b/Ambit/Source/Ambit/Ambit.Build.cs
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //   
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/AmbitModule.cpp
+++ b/Ambit/Source/Ambit/AmbitModule.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/AmbitModule.h
+++ b/Ambit/Source/Ambit/AmbitModule.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AWSRegionDropdownMenu.cpp
+++ b/Ambit/Source/Ambit/Mode/AWSRegionDropdownMenu.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AWSRegionDropdownMenu.h
+++ b/Ambit/Source/Ambit/Mode/AWSRegionDropdownMenu.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitDetailCustomization.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitDetailCustomization.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitDetailCustomization.h
+++ b/Ambit/Source/Ambit/Mode/AmbitDetailCustomization.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitMode.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitMode.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitMode.h
+++ b/Ambit/Source/Ambit/Mode/AmbitMode.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitObject.h
+++ b/Ambit/Source/Ambit/Mode/AmbitObject.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWeather.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWeather.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWeather.h
+++ b/Ambit/Source/Ambit/Mode/AmbitWeather.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.h
+++ b/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWeatherParameters.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWidget.cpp
+++ b/Ambit/Source/Ambit/Mode/AmbitWidget.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/AmbitWidget.h
+++ b/Ambit/Source/Ambit/Mode/AmbitWidget.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.cpp
+++ b/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.h
+++ b/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/BulkScenarioConfiguration.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExport.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ConfigImportExportInterface.h
+++ b/Ambit/Source/Ambit/Mode/ConfigImportExportInterface.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/Constant.h
+++ b/Ambit/Source/Ambit/Mode/Constant.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/DropdownMenuBase.h
+++ b/Ambit/Source/Ambit/Mode/DropdownMenuBase.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ExportPlatforms.cpp
+++ b/Ambit/Source/Ambit/Mode/ExportPlatforms.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ExportPlatforms.h
+++ b/Ambit/Source/Ambit/Mode/ExportPlatforms.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExport.cpp
+++ b/Ambit/Source/Ambit/Mode/GltfExport.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExport.h
+++ b/Ambit/Source/Ambit/Mode/GltfExport.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExport.spec.cpp
+++ b/Ambit/Source/Ambit/Mode/GltfExport.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExportInterface.h
+++ b/Ambit/Source/Ambit/Mode/GltfExportInterface.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExporterExternal.cpp
+++ b/Ambit/Source/Ambit/Mode/GltfExporterExternal.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExporterExternal.h
+++ b/Ambit/Source/Ambit/Mode/GltfExporterExternal.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfExporterExternalInterface.h
+++ b/Ambit/Source/Ambit/Mode/GltfExporterExternalInterface.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfFileTypeDropdownMenu.cpp
+++ b/Ambit/Source/Ambit/Mode/GltfFileTypeDropdownMenu.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/GltfFileTypeDropdownMenu.h
+++ b/Ambit/Source/Ambit/Mode/GltfFileTypeDropdownMenu.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/IScenarioParameter.h
+++ b/Ambit/Source/Ambit/Mode/IScenarioParameter.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/PedestrianTraffic.cpp
+++ b/Ambit/Source/Ambit/Mode/PedestrianTraffic.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/PedestrianTraffic.h
+++ b/Ambit/Source/Ambit/Mode/PedestrianTraffic.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ScenarioDefinition.cpp
+++ b/Ambit/Source/Ambit/Mode/ScenarioDefinition.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/ScenarioDefinition.h
+++ b/Ambit/Source/Ambit/Mode/ScenarioDefinition.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/StringDropdownMenuBase.h
+++ b/Ambit/Source/Ambit/Mode/StringDropdownMenuBase.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TestClasses/ConfigImportExportMock.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/ConfigImportExportMock.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TestClasses/GltfExportMock.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/GltfExportMock.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TestClasses/GltfExporterExternalMock.h
+++ b/Ambit/Source/Ambit/Mode/TestClasses/GltfExporterExternalMock.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TimeOfDayDropdownMenu.cpp
+++ b/Ambit/Source/Ambit/Mode/TimeOfDayDropdownMenu.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TimeOfDayDropdownMenu.h
+++ b/Ambit/Source/Ambit/Mode/TimeOfDayDropdownMenu.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TimeOfDayTypes.cpp
+++ b/Ambit/Source/Ambit/Mode/TimeOfDayTypes.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/TimeOfDayTypes.h
+++ b/Ambit/Source/Ambit/Mode/TimeOfDayTypes.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/VehicleTraffic.cpp
+++ b/Ambit/Source/Ambit/Mode/VehicleTraffic.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/VehicleTraffic.h
+++ b/Ambit/Source/Ambit/Mode/VehicleTraffic.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/WeatherDropdownMenu.cpp
+++ b/Ambit/Source/Ambit/Mode/WeatherDropdownMenu.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/WeatherDropdownMenu.h
+++ b/Ambit/Source/Ambit/Mode/WeatherDropdownMenu.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/WeatherTypes.cpp
+++ b/Ambit/Source/Ambit/Mode/WeatherTypes.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Mode/WeatherTypes.h
+++ b/Ambit/Source/Ambit/Mode/WeatherTypes.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AWSWrapper.cpp
+++ b/Ambit/Source/Ambit/Utils/AWSWrapper.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AWSWrapper.h
+++ b/Ambit/Source/Ambit/Utils/AWSWrapper.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitFileHelpers.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitFileHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitFileHelpers.h
+++ b/Ambit/Source/Ambit/Utils/AmbitFileHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.h
+++ b/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitSpawnerCollisionHelpers.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.h
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
+++ b/Ambit/Source/Ambit/Utils/AmbitWorldHelpers.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/MatchBy.h
+++ b/Ambit/Source/Ambit/Utils/MatchBy.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/UserMetricsSubsystem.cpp
+++ b/Ambit/Source/Ambit/Utils/UserMetricsSubsystem.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Utils/UserMetricsSubsystem.h
+++ b/Ambit/Source/Ambit/Utils/UserMetricsSubsystem.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehicleHelpers.cpp
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehicleHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehicleHelpers.h
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehicleHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.cpp
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.h
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.spec.cpp
+++ b/Ambit/Source/Ambit/Vehicle/AmbitVehiclePIDController.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitWheeledVehicleAIController.cpp
+++ b/Ambit/Source/Ambit/Vehicle/AmbitWheeledVehicleAIController.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/AmbitWheeledVehicleAIController.h
+++ b/Ambit/Source/Ambit/Vehicle/AmbitWheeledVehicleAIController.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/Ambit/Vehicle/Constant.h
+++ b/Ambit/Source/Ambit/Vehicle/Constant.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/AmbitUtils.Build.cs
+++ b/Ambit/Source/AmbitUtils/AmbitUtils.Build.cs
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //   
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/AmbitUtilsModule.cpp
+++ b/Ambit/Source/AmbitUtils/AmbitUtilsModule.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/AmbitUtilsModule.h
+++ b/Ambit/Source/AmbitUtils/AmbitUtilsModule.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/ConfigJsonSerializer.h
+++ b/Ambit/Source/AmbitUtils/ConfigJsonSerializer.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/JsonHelpers.cpp
+++ b/Ambit/Source/AmbitUtils/JsonHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/JsonHelpers.h
+++ b/Ambit/Source/AmbitUtils/JsonHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/MathHelpers.cpp
+++ b/Ambit/Source/AmbitUtils/MathHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/MathHelpers.h
+++ b/Ambit/Source/AmbitUtils/MathHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/MathHelpers.spec.cpp
+++ b/Ambit/Source/AmbitUtils/MathHelpers.spec.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/MenuHelpers.cpp
+++ b/Ambit/Source/AmbitUtils/MenuHelpers.cpp
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/Source/AmbitUtils/MenuHelpers.h
+++ b/Ambit/Source/AmbitUtils/MenuHelpers.h
@@ -1,4 +1,4 @@
-//   Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//   Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  
 //   Licensed under the Apache License, Version 2.0 (the "License").
 //   You may not use this file except in compliance with the License.

--- a/Ambit/THIRD_PARTY_LICENSES.md
+++ b/Ambit/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,255 @@
+AWS Ambit Scenario Designer for Unreal Engine 4 version 1.0 uses the Unreal® Engine. Unreal® is a trademark or registered trademark of Epic Games, Inc. in the United States of America and elsewhere
+
+Unreal® Engine, Copyright 1998 – 2021, Epic Games, Inc. All rights reserved.
+
+------
+
+Contains texture assets from [ambientCG.com](https://ambientcg.com/), licensed under [CC0 1.0 Universal](https://creativecommons.org/share-your-work/public-domain/cc0/). Thank you, AmbientCG! These include:
+
+- Asphalt 014
+- Concrete 010
+- Concrete 017
+- Concrete 020
+- Concrete 037
+- Grass 004
+- Ground 029
+- Wood 027
+
+------
+AWS Ambit Scenario Designer for Unreal Engine 4 version 1.0 includes the following third-party software/licensing:
+
+** aws-sdk-cpp; version 1.9.113 -- https://github.com/aws/aws-sdk-cpp
+ 
+                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+* For aws-sdk-cpp see also this required NOTICE:
+    AWS SDK for C++
+    Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+    This product includes software developed by
+    Amazon Technologies, Inc (http://www.amazon.com/).
+
+------
+
+** Houdini Engine for Unreal - Version 2; version 2.0.4 -- https://github.com/sideeffects/HoudiniEngineForUnreal-v2
+Copyright (c) 2021 Side Effects Software Inc. All rights reserved.
+ 
+Copyright (c) 2021 Side Effects Software Inc. All rights reserved.
+Redistribution and use of in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+The names Side Effects Software and SideFX may not be used to endorse or promote
+products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY SIDE EFFECTS SOFTWARE `AS IS' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL SIDE EFFECTS SOFTWARE BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.

--- a/config/Ambit_Resharper.DotSettings
+++ b/config/Ambit_Resharper.DotSettings
@@ -36,8 +36,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CppSortIncludes/UnmatchedHeaderOrder/@EntryValue">6</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/EnableClangFormatSupport/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/EditorConfig/SyncToVisualStudio/@EntryValue">True</s:Boolean>
-	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.&#xD;
- &#xD;
+	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">  Copyright $CURRENT_YEAR$ Amazon.com, Inc. or its affiliates. All Rights Reserved.&#xD;
   Licensed under the Apache License, Version 2.0 (the "License").&#xD;
   You may not use this file except in compliance with the License.&#xD;
   You may obtain a copy of the License at&#xD;


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)
* Update all header information to include current year (2022)
* Add in Marketplace URL
* Added in "WhitelistPlatforms" to each Module
* Update the minor version, which will need to repackage after this change
* Add in Config/* to the output package
* Minor: Update the DotSettings to include current year in header

## What was the solution? (How)
Epic has specified that we need to make a few changes before we can publish. These are:
* .uplugin has "MarketplaceURL" key with a value that includes the product's Offer ID -- Fail -- For this product the value is "com.epicgames.launcher://ue/marketplace/product/cb1034a325c94e52b3ed08f6eb9ae4a0"
* All source and header files contain a commented copyright notice with Publisher name and year of publishing -- Fail -- All code files must have the intended year of publication in the copyright comment.
* FilterPlugin.ini filters in custom folders the publisher intends to distribute (Docs or similar) -- Fail -- The FilterPlugin.ini needs to list all folders or files that are outside the expected file structure and are intended to be included.


## What is the impact of this change?
This should have no usability impact

## Are you adding any new dependencies to the system?
N/A

## How were these changes tested?
Packaged through Editor and manually to verify it was successful

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
